### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/one2track/__init__.py
+++ b/custom_components/one2track/__init__.py
@@ -134,9 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     for component in PLATFORMS:
         LOGGER.debug(f"[one2track] creating tracker for: {entry}")
-        await hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+        await hass.config_entries.async_forward_entry_setups(entry, [component])
 
     return True
 


### PR DESCRIPTION
This PR fixes a breaking change with Home Assistant Core 2024+ where the method
`async_forward_entry_setup` was removed and replaced by
`async_forward_entry_setups`.

- Replaced `async_forward_entry_setup` with `await async_forward_entry_setups(entry, [component])`
- Fixed async task usage in `custom_components/one2track/__init__.py`

This resolves the error:

AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'

Tested on Home Assistant Core 2024.0.0 and works without errors.

Thanks for maintaining this integration!
